### PR TITLE
PatternProperties, ConstSchema and improvement over Enum

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,6 +34,9 @@ export function throughJsonSchema(schema: JSONSchema | JSONSchema[], action: (sc
         if (schema.not) {
             throughJsonSchema(schema.not as JSONSchema, action)
         }
+        if (schema.patternProperties) {
+            throughJsonSchema(schema.patternProperties, action)
+        }
         if (schema.additionalProperties && typeof schema.additionalProperties !== "boolean") {
             throughJsonSchema(schema.additionalProperties, action)
         }


### PR DESCRIPTION
# Summary
- New function that allow to add patternProperties with typing. (Does not support typing accuracy of full regex pattern. Limited in usage.)
- New Static function to create a const schema for narrowing property to a specific type.
- Improvement on typing argument which allow single value enum to be used without being in an array. Similar behaviour as constSchema.
- Test for patternProperties, enumSchema with single value and constSchema.

Minor version bump